### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 # Teams can be specified as code owners as well. Teams should
 # be identified in the format @org/team-name. Teams must have
 # explicit write access to the repository.
-*       @The-Strategy-Unit/data-science-team
+*       @yiwen-h


### PR DESCRIPTION
Making YiWen CODEOWNER rather than the entire Data Science team due to annoying auto-notifications.

I've also removed the requirement that PR must be approved by CODEOWNER.

This means that YiWen will be auto-assigned - but she can reassign and anyone can review.