### PR TITLE
Update glossary.qmd from confidence intervals to prediction intervals

### DIFF
--- a/user_guide/glossary.qmd
+++ b/user_guide/glossary.qmd
@@ -9,11 +9,11 @@ This page clarifies the terminology that is used throughout the model and its as
 
 Bed days are defined as `discharge_date - admission_date + 1`.
 
-## Confidence intervals
+## Prediction intervals
 
-A confidence interval (CI) is an interval which is expected to typically contain the parameter being estimated. In the context of the NHP Demand and Capacity model, we show results in terms of a principal projection, as well as 90% (upper) and 10% (lower) confidence intervals showing the range of possibilities in the modelled future. For example, if the model's principal projection for beddays is 200,000 and the upper and lower confidence intervals are 210,000 and 190,000, then this indicates that we are 80% confident that the true value will be within this range.
+A prediction interval (PI) is an interval which is expected to typically contain the parameter being estimated. In the context of the NHP Demand and Capacity model, we show results in terms of a principal projection, as well as 90% (upper) and 10% (lower) prediction intervals showing the range of possibilities in the modelled future. For example, if the model's principal projection for beddays is 200,000 and the upper and lower prediction intervals are 210,000 and 190,000, then this indicates our belief that there is an 80% chance that the true value will be within this range.
 
-On the 'Distribution of projections' section of the outputs app, we have the tabs 'activity summary' (a summary table) and 'activity distribution' (contains the S-curve). Summing the values for the upper and lower confidence intervals on the summary table can give different results to the numbers seen on the S-curve chart for the upper and lower confidence intervals. 
+On the 'Distribution of projections' section of the outputs app, we have the tabs 'activity summary' (a summary table) and 'activity distribution' (contains the S-curve). Summing the values for the upper and lower prediction intervals on the summary table can give different results to the numbers seen on the S-curve chart for the upper and lower prediction intervals. 
 
 The reason for this is that the summary table calculates the lower and upper values separately for each point of delivery (POD), which means you’re effectively taking a summary of a summary by adding these values together. This contrasts with calculating the lower and upper for all inpatient Point of Deliveries (PODs) together, where all the data is used to generate the summary values and information is not 'lost'. In other words, we can expect the two types of calculation to yield slightly different results.
 
@@ -63,7 +63,7 @@ So the percentile values for Table 1's "Total" column are 187 and 270. But if yo
 
 ## Distribution of projections
 
-The results of the (usually 256) Monte Carlo simulation runs, each of which will randomly sample from the 80% confidence intervals supplied as the model parameters. The "central projection" is the median result from the 256 runs.  
+The results of the (usually 256) Monte Carlo simulation runs, each of which will randomly sample from the 80% prediction intervals supplied as the model parameters. The "central projection" is the median result from the 256 runs.  
 
 ## Empirical Cumulative Distribution Function (ECDF) Curve / S-Curve
 
@@ -169,7 +169,7 @@ The key outputs of the model are estimates of future hospital activity. The prin
 
 For model v2.0 onwards, the principal projection is the average (mean) of all the 256 Monte Carlo simulations which have been run for a scenario. In the outputs, users will see a principal projection figure for all the different types of activity which the model forecasts. This approach to determining the principal projection was adopted in July 2024. It ensures that the principal projection will sit in the middle of the activity distribution (i.e. it will be very close to the 50th percentile or median).
 
-For model versions up to and including v1.2, the principal projection was determined by a single model run which took the midpoint of all the parameter confidence intervals set by the user. However, given the probabilistic nature of the model, we have found that using the average of all the simulations is a more stable method of determining the principal projection.  
+For model versions up to and including v1.2, the principal projection was determined by a single model run which took the midpoint of all the parameter prediction intervals set by the user. However, given the probabilistic nature of the model, we have found that using the average of all the simulations is a more stable method of determining the principal projection.  
 
 This is not to be confused with the ONS principal population projection. 
 

--- a/user_guide/glossary.qmd
+++ b/user_guide/glossary.qmd
@@ -11,7 +11,7 @@ Bed days are defined as `discharge_date - admission_date + 1`.
 
 ## Prediction intervals
 
-A prediction interval (PI) is an interval which is expected to typically contain the parameter being estimated. In the context of the NHP Demand and Capacity model, we show results in terms of a principal projection, as well as 90% (upper) and 10% (lower) prediction intervals showing the range of possibilities in the modelled future. For example, if the model's principal projection for beddays is 200,000 and the upper and lower prediction intervals are 210,000 and 190,000, then this indicates our belief that there is an 80% chance that the true value will be within this range.
+A prediction interval (PI) is an interval which is expected to typically contain the variable being estimated. In the context of the NHP Demand and Capacity model, we show results in terms of a principal projection, as well as 90% (upper) and 10% (lower) prediction intervals showing the range of possibilities in the modelled future. For example, if the model's principal projection for beddays is 200,000 and the upper and lower prediction intervals are 210,000 and 190,000, then this indicates the actual number of beddays in the horizon year should lie between this interval with probability 0.8.
 
 On the 'Distribution of projections' section of the outputs app, we have the tabs 'activity summary' (a summary table) and 'activity distribution' (contains the S-curve). Summing the values for the upper and lower prediction intervals on the summary table can give different results to the numbers seen on the S-curve chart for the upper and lower prediction intervals. 
 


### PR DESCRIPTION
Changing text from 'confidence intervals' to 'prediction intervals' (8 occurrences - 6 in 'confidence/prediction intervals', 1 in 'distribution of projections' and 1 in 'principal projection'.

Also changed sentence describing '**80% confident that the true value**...' to '**80% chance...**' - this will require review.