### PR TITLE
🚸 Simplify sidebar collapse to level 1

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -17,6 +17,7 @@ website:
   sidebar:
     style: "floating"
     search: true
+    collapse-level: 1
     contents:
       - section: "Project overview"
         contents:


### PR DESCRIPTION
Default collapse set to `1` rather than `2`.

This means only headings will show, and users can click to expand. 
I think this makes the sidebar cleaner and less overwhelming for new users

## Before
<img width="672" alt="level-2" src="https://github.com/user-attachments/assets/ea09a98f-2814-400f-83c6-4b9548f97c4c">

## After
<img width="674" alt="level-1" src="https://github.com/user-attachments/assets/2c31556c-f078-41df-be13-fa127b058e1b">
