### PR TITLE
switch to using SAS tokens for data access

### DIFF
--- a/.Renviron.example
+++ b/.Renviron.example
@@ -1,6 +1,5 @@
-AZ_APP_ID=
-AZ_APP_SECRET=
+AZ_STORAGE_ACCOUNT=
+
 AZ_STORAGE_CONTAINER_SUPPORT=
-AZ_STORAGE_EP=
-AZ_STORAGE_KEY=
-AZ_TENANT_ID=
+# generate a read-only SAS token for the support container using update_secrets.ps1
+AZ_STORAGE_CONTAINER_SUPPORT_SAS=

--- a/.github/workflows/connect-publish-dev.yaml
+++ b/.github/workflows/connect-publish-dev.yaml
@@ -23,8 +23,8 @@ jobs:
         shell: bash
         env:
           QUARTO_PRINT_STACK: true
-          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL_NEW }}
-          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY_NEW }}
+          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL }}
+          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY }}
           AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
           AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}

--- a/.github/workflows/connect-publish-dev.yaml
+++ b/.github/workflows/connect-publish-dev.yaml
@@ -23,19 +23,12 @@ jobs:
         shell: bash
         env:
           QUARTO_PRINT_STACK: true
-          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL }}
-          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY }}
-          AZ_APP_ID: ${{ secrets.AZ_APP_ID }}
-          AZ_APP_SECRET: ${{ secrets.AZ_APP_SECRET }}
+          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL_NEW }}
+          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY_NEW }}
+          AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
-          AZ_STORAGE_EP: ${{ secrets.AZ_STORAGE_EP }}
-          AZ_STORAGE_KEY: ${{ secrets.AZ_STORAGE_KEY }}
-          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
-        run: |
-          git config --global user.email "quarto-github-actions-publish@example.com"
-          git config --global user.name "Quarto GHA Workflow Runner"
-
-          quarto publish --id 8f2cb2e8-c576-494b-a2a1-adcce3ecd833 --no-browser
+          AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}
+        run: quarto publish --id 8f2cb2e8-c576-494b-a2a1-adcce3ecd833 --no-browser
 
       - name: Publish to NEW RStudio Connect (and render)
         shell: bash
@@ -43,14 +36,7 @@ jobs:
           QUARTO_PRINT_STACK: true
           CONNECT_SERVER: ${{ secrets.RSCONNECT_URL_NEW }}
           CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY_NEW }}
-          AZ_APP_ID: ${{ secrets.AZ_APP_ID }}
-          AZ_APP_SECRET: ${{ secrets.AZ_APP_SECRET }}
+          AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
-          AZ_STORAGE_EP: ${{ secrets.AZ_STORAGE_EP }}
-          AZ_STORAGE_KEY: ${{ secrets.AZ_STORAGE_KEY }}
-          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
-        run: |
-          git config --global user.email "quarto-github-actions-publish@example.com"
-          git config --global user.name "Quarto GHA Workflow Runner"
-
-          quarto publish --id 1feb633e-81c0-4a34-8a71-cc7338f03375 --no-browser
+          AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}
+        run: quarto publish --id 1feb633e-81c0-4a34-8a71-cc7338f03375 --no-browser

--- a/.github/workflows/connect-publish-pr.yaml
+++ b/.github/workflows/connect-publish-pr.yaml
@@ -27,19 +27,12 @@ jobs:
         shell: bash
         env:
           QUARTO_PRINT_STACK: true
-          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL }}
-          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY }}
-          AZ_APP_ID: ${{ secrets.AZ_APP_ID }}
-          AZ_APP_SECRET: ${{ secrets.AZ_APP_SECRET }}
+          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL_NEW }}
+          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY_NEW }}
+          AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
-          AZ_STORAGE_EP: ${{ secrets.AZ_STORAGE_EP }}
-          AZ_STORAGE_KEY: ${{ secrets.AZ_STORAGE_KEY }}
-          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
-        run: |
-          git config --global user.email "quarto-github-actions-publish@example.com"
-          git config --global user.name "Quarto GHA Workflow Runner"
-
-          quarto publish connect --id a3a013e9-d405-46b7-a71e-1fae05a569f4 --no-browser
+          AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}
+        run: quarto publish --id a3a013e9-d405-46b7-a71e-1fae05a569f4 --no-browser
 
       - name: Publish to NEW RStudio Connect (and render)
         shell: bash
@@ -47,14 +40,7 @@ jobs:
           QUARTO_PRINT_STACK: true
           CONNECT_SERVER: ${{ secrets.RSCONNECT_URL_NEW }}
           CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY_NEW }}
-          AZ_APP_ID: ${{ secrets.AZ_APP_ID }}
-          AZ_APP_SECRET: ${{ secrets.AZ_APP_SECRET }}
+          AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
-          AZ_STORAGE_EP: ${{ secrets.AZ_STORAGE_EP }}
-          AZ_STORAGE_KEY: ${{ secrets.AZ_STORAGE_KEY }}
-          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
-        run: |
-          git config --global user.email "quarto-github-actions-publish@example.com"
-          git config --global user.name "Quarto GHA Workflow Runner"
-
-          quarto publish connect --id 8a793bc6-6399-4260-b2c9-10fc040fda6f --no-browser
+          AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}
+        run: quarto publish --id 8a793bc6-6399-4260-b2c9-10fc040fda6f --no-browser

--- a/.github/workflows/connect-publish-pr.yaml
+++ b/.github/workflows/connect-publish-pr.yaml
@@ -27,8 +27,8 @@ jobs:
         shell: bash
         env:
           QUARTO_PRINT_STACK: true
-          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL_NEW }}
-          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY_NEW }}
+          CONNECT_SERVER: ${{ secrets.RSCONNECT_URL }}
+          CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY }}
           AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
           AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}

--- a/.github/workflows/connect-publish-prod.yaml
+++ b/.github/workflows/connect-publish-prod.yaml
@@ -25,17 +25,10 @@ jobs:
           QUARTO_PRINT_STACK: true
           CONNECT_SERVER: ${{ secrets.RSCONNECT_URL }}
           CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY }}
-          AZ_APP_ID: ${{ secrets.AZ_APP_ID }}
-          AZ_APP_SECRET: ${{ secrets.AZ_APP_SECRET }}
+          AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
-          AZ_STORAGE_EP: ${{ secrets.AZ_STORAGE_EP }}
-          AZ_STORAGE_KEY: ${{ secrets.AZ_STORAGE_KEY }}
-          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
-        run: |
-          git config --global user.email "quarto-github-actions-publish@example.com"
-          git config --global user.name "Quarto GHA Workflow Runner"
-
-          quarto publish --id e0c5e8f2-c27f-4b25-ac3a-4659e9eff53f --no-browser
+          AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}
+        run: quarto publish --id e0c5e8f2-c27f-4b25-ac3a-4659e9eff53f --no-browser
 
       - name: Publish to NEW RStudio Connect (and render)
         shell: bash
@@ -43,14 +36,7 @@ jobs:
           QUARTO_PRINT_STACK: true
           CONNECT_SERVER: ${{ secrets.RSCONNECT_URL_NEW }}
           CONNECT_API_KEY: ${{ secrets.RSCONNECT_API_KEY_NEW }}
-          AZ_APP_ID: ${{ secrets.AZ_APP_ID }}
-          AZ_APP_SECRET: ${{ secrets.AZ_APP_SECRET }}
+          AZ_STORAGE_ACCOUNT: ${{ secrets.AZ_STORAGE_ACCOUNT }}
           AZ_STORAGE_CONTAINER_SUPPORT: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT }}
-          AZ_STORAGE_EP: ${{ secrets.AZ_STORAGE_EP }}
-          AZ_STORAGE_KEY: ${{ secrets.AZ_STORAGE_KEY }}
-          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
-        run: |
-          git config --global user.email "quarto-github-actions-publish@example.com"
-          git config --global user.name "Quarto GHA Workflow Runner"
-
-          quarto publish --id 34d94a7c-fb1c-4aa6-8af9-1bc8e34b4b86 --no-browser
+          AZ_STORAGE_CONTAINER_SUPPORT_SAS: ${{ secrets.AZ_STORAGE_CONTAINER_SUPPORT_SAS }}
+        run: quarto publish --id 34d94a7c-fb1c-4aa6-8af9-1bc8e34b4b86 --no-browser

--- a/update_secrets.ps1
+++ b/update_secrets.ps1
@@ -1,0 +1,61 @@
+function Get-StorageAccountSasToken {
+  Param (
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string] $storageAccountName,
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string] $containerName
+  )
+
+  $accountKey = az storage account keys list `
+    --account-name $storageAccountName `
+    --query '[0].value' `
+    --output tsv
+
+  if (-not $accountKey) {
+    Write-Error 'Failed to retrieve account key'
+    return
+  }
+
+  $expiry = (Get-Date).AddMonths(1).ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+  $sasToken = az storage container generate-sas `
+    --account-name $storageAccountName `
+    --account-key $accountKey `
+    --name $containerName `
+    --permissions r `
+    --expiry $expiry `
+    --https-only `
+    --output tsv
+
+  return $sasToken
+}
+
+function Set-StorageAccountSasToken {
+  Param (
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string] $storageAccountName,
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string] $containerName
+  )
+  $sasToken = Get-StorageAccountSasToken $storageAccountName $containerName
+  
+  gh secret set AZ_STORAGE_CONTAINER_SUPPORT_SAS `
+    -R The-Strategy-Unit/nhp_project_information `
+    -b $sasToken
+
+  (Get-Content .Renviron) `
+    -replace '^AZ_STORAGE_CONTAINER_SUPPORT_SAS=.*$', "AZ_STORAGE_CONTAINER_SUPPORT_SAS=$sasToken" `
+  | Set-Content .Renviron
+}
+
+# load .Renviron file as environment variables
+Get-Content .Renviron | ForEach-Object {
+  $name, $value = $_.split('=')
+  if ([string]::IsNullOrWhiteSpace($name) -or $name.Contains('#')) {
+    # skip empty or comment line in ENV file
+    return
+  }
+  Set-Content env:\$name $value
+}
+
+Set-StorageAccountSasToken $env:AZ_STORAGE_ACCOUNT $env:AZ_STORAGE_CONTAINER_SUPPORT

--- a/user_guide/mitigators_lookup.qmd
+++ b/user_guide/mitigators_lookup.qmd
@@ -15,22 +15,21 @@ The variable names for each strategy are also included. These are used when inte
 ```{r}
 #| label: mitigators-table
 
-library(readr)  # forces readr in AzureStor::storage_read_csv
+library(readr) # forces readr in AzureStor::storage_read_csv
 
-get_container <- function(container_name) {
+get_support_container <- function() {
+  container_name <- Sys.getenv("AZ_STORAGE_CONTAINER_SUPPORT")
+  sas_token <- Sys.getenv("AZ_STORAGE_CONTAINER_SUPPORT_SAS")
+  storage_account <- Sys.getenv("AZ_STORAGE_ACCOUNT")
 
-  ep_uri <- Sys.getenv("AZ_STORAGE_EP")
-  app_id <- Sys.getenv("AZ_APP_ID")
-  sa_key <- Sys.getenv("AZ_STORAGE_KEY")
+  ep_uri <- glue::glue("https://{storage_account}.blob.core.windows.net")
 
   ep_uri |>
-    AzureStor::blob_endpoint(key = sa_key) |>
+    AzureStor::blob_endpoint(sas = sas_token) |>
     AzureStor::storage_container(container_name)
-
 }
 
-support_container <- Sys.getenv("AZ_STORAGE_CONTAINER_SUPPORT") |>
-  get_container()
+support_container <- get_support_container()
 
 lookup <- AzureStor::storage_read_csv(
   support_container,
@@ -38,7 +37,7 @@ lookup <- AzureStor::storage_read_csv(
   col_types = "c"
 )
 
-dat <- lookup |> 
+dat <- lookup |>
   dplyr::select(
     Code = mitigator_code,
     Activity = "activity_type",
@@ -47,7 +46,7 @@ dat <- lookup |>
     Variable = "mitigator_variable",
     From = "active_from",
     To = "active_to"
-  ) |> 
+  ) |>
   dplyr::mutate(
     Activity = dplyr::if_else(
       Activity == "aae",
@@ -55,7 +54,7 @@ dat <- lookup |>
       stringr::str_to_upper(Activity)
     ),
     Type = Type |> stringr::str_to_title() |> stringr::str_replace("_", " ")
-  ) |> 
+  ) |>
   tidyr::replace_na(list(To = "-"))
 
 htmltools::tagList(
@@ -73,10 +72,10 @@ htmltools::tagList(
       "Code" = reactable::colDef(maxWidth = 100),
       "Activity" = reactable::colDef(maxWidth = 75),
       "Type" = reactable::colDef(maxWidth = 105),
-      "From"  = reactable::colDef(maxWidth = 70),
+      "From" = reactable::colDef(maxWidth = 70),
       "To" = reactable::colDef(maxWidth = 70)
     )
   )
-) |> 
+) |>
   htmltools::browsable()
 ```


### PR DESCRIPTION
resolves #199 - previously we were using the storage account key which was insecure. This changes the code to use SAS tokens instead. The key benefits are:

- scope is read access only, whereas the key has essentially admin level permissions
- scope is to the single container we need access to, not to all data in the storage account
