### PR TITLE
Revert "force earlier version of quarto, 1.8 isn't publishing"

### DIFF
--- a/.github/workflows/connect-publish-dev.yaml
+++ b/.github/workflows/connect-publish-dev.yaml
@@ -12,8 +12,6 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: 1.7.34
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/connect-publish-pr.yaml
+++ b/.github/workflows/connect-publish-pr.yaml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: 1.7.34
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/connect-publish-prod.yaml
+++ b/.github/workflows/connect-publish-prod.yaml
@@ -12,8 +12,6 @@ jobs:
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: 1.7.34
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
This reverts commit ba75e9306b8dfad5fcabb48bb4fb5018528a6eed. Closes #273

