### PR TITLE
Update data log for v4.2.1

### DIFF
--- a/data_extraction/data_log.qmd
+++ b/data_extraction/data_log.qmd
@@ -5,6 +5,11 @@ order: 250
 
 This page contains information about changes to the data underpinning the NHP model. If there are no changes logged for a particular version (such as 1.0) then the changes were only to the model code, and not to the underlying data.
 
+## Version 4.2.1
+
+Date updated: 07/10/2025
+Please see the [release notes for v4.2.1](https://github.com/The-Strategy-Unit/nhp_data/releases/tag/v4.2.1) on the [nhp_data](https://github.com/The-Strategy-Unit/nhp_data) repository.
+
 ## Version 4.2
 
 Date updated: 01/10/2025


### PR DESCRIPTION
Added section for v4.2.1 patch release, given [the update to NHP data](https://github.com/The-Strategy-Unit/nhp_data/releases/tag/v4.2.1).