### PR TITLE
fix: CI

### DIFF
--- a/.github/workflows/connect-publish-dev.yaml
+++ b/.github/workflows/connect-publish-dev.yaml
@@ -2,6 +2,7 @@ name: "Connect Publish (dev)"
 on:
   push:
     branches: [main]
+  pull_request:
 
 jobs:
   connect-publish:

--- a/.github/workflows/connect-publish-dev.yaml
+++ b/.github/workflows/connect-publish-dev.yaml
@@ -2,7 +2,6 @@ name: "Connect Publish (dev)"
 on:
   push:
     branches: [main]
-  pull_request:
 
 jobs:
   connect-publish:

--- a/.github/workflows/connect-publish-dev.yaml
+++ b/.github/workflows/connect-publish-dev.yaml
@@ -8,7 +8,7 @@ jobs:
     name: connect-publish-dev
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -16,6 +16,10 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: "4.4"
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libcurl4-openssl-dev
 
       - uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/connect-publish-pr.yaml
+++ b/.github/workflows/connect-publish-pr.yaml
@@ -21,6 +21,10 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: "4.4"
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libcurl4-openssl-dev
 
       - uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/connect-publish-prod.yaml
+++ b/.github/workflows/connect-publish-prod.yaml
@@ -2,6 +2,7 @@ name: "Connect Publish (prod)"
 on:
   release:
     types: [published]
+  pull_request:
 
 jobs:
   connect-publish:
@@ -16,6 +17,10 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+          r-version: "4.4"
+
+      - name: Install system dependencies
+        run: sudo apt-get install -y libcurl4-openssl-dev
 
       - uses: r-lib/actions/setup-renv@v2
 

--- a/.github/workflows/connect-publish-prod.yaml
+++ b/.github/workflows/connect-publish-prod.yaml
@@ -2,7 +2,6 @@ name: "Connect Publish (prod)"
 on:
   release:
     types: [published]
-  pull_request:
 
 jobs:
   connect-publish:


### PR DESCRIPTION
Closes #338 , #325 

This pull request updates the GitHub Actions workflow for the `connect-publish-dev` job to improve compatibility and reliability. The main changes include updating action versions, specifying the R version, and ensuring required system dependencies are installed.

**Workflow updates and dependencies:**

* Updated the `actions/checkout` step from version 3 to version 4 for better support and security.
* Set the R version explicitly to `"4.4"` in the `setup-r` step to ensure consistent R environment across runs.
* Added a step to install the `libcurl4-openssl-dev` system dependency, which is often required for R packages that need curl support.