### PR TITLE
Amend model update for v5.2

### DIFF
--- a/project_plan_and_summary/model_updates.qmd
+++ b/project_plan_and_summary/model_updates.qmd
@@ -14,9 +14,12 @@ Previously it was when the admission-method code started with a 3.
 Now it's when the admission-method code starts with a 3 _or_ the treatment specialty code is 501 or 560, but only for female patients between the ages of 13 and 55.
 Please see [the full 'group' definition in the Data Extraction section](../data_extraction/inpatients.html#group).
 
+This impacts the maternity and elective inpatient points-of-delivery (PODs), so there's likely to be differences in your results.
+Please check your baseline data again.
+
 ### Removal of time profiles
 
-Previously, users were able to choose the rate of change to the horizon year for a given prediction: front-loaded, back-loaded, step change or linear. 
+Previously, users were able to choose the rate of change to the horizon year for a given prediction: front-loaded, back-loaded, step change or linear.
 This functionality was only of use in the generation of 'time profiles', a product which has now been retired.
 We have therefore removed this selection in the inputs app.
 

--- a/project_plan_and_summary/model_updates.qmd
+++ b/project_plan_and_summary/model_updates.qmd
@@ -3,15 +3,22 @@ title: "Model updates"
 order: 5
 ---
 
-# Update 2026/06/08
+# Update 2026/06/24
+
+## v5.2.0
+
+### Updated maternity definition
+
+The definition of maternity in the model has been updated.
+Previously it was when the admission-method code started with a 3.
+Now it's when the admission-method code starts with a 3 _or_ the treatment specialty code is 501 or 560, but only for female patients between the ages of 13 and 55.
+Please see [the full 'group' definition in the Data Extraction section](../data_extraction/inpatients.html#group).
 
 ### Removal of time profiles
 
-Previously users were able to select between several options for how they predicted
-the effect of mitigations for a TPMA might change activity rates over time (front-loaded,
-back-loaded, step change or linear). This functionality was only of use in the generation of 
-'time profiles', a product which has now been retired. We have therefore removed
-this selection in the inputs app.
+Previously, users were able to choose the rate of change to the horizon year for a given prediction: front-loaded, back-loaded, step change or linear. 
+This functionality was only of use in the generation of 'time profiles', a product which has now been retired.
+We have therefore removed this selection in the inputs app.
 
 # Update 2026/05/29
 


### PR DESCRIPTION
Close #368.

* Added subsection re maternity definition.
* Standardised line-breaking in time-profiles subsection.
* Tweaked first line of time-profiles subsection to remove explicit reference to TPMAs (time-profiles were applied to other parameters too).
* Updated section date and version.