### PR TITLE
Use javascript for tables

### DIFF
--- a/project_plan_and_summary/model_updates.qmd
+++ b/project_plan_and_summary/model_updates.qmd
@@ -598,7 +598,7 @@ The interaction between the various factors in the model has in the past been re
 However, we found this created inconsistencies in specific scenarios.
 To address this, we now show the Model Interaction Term as a separate value in the waterfall charts.
 
-Further detail on the [impact of change](user_guide/glossary.qmd#impact-of-changes) can be found in the [glossary](user_guide/glossary.qmd).
+Further detail on the [impact of change](../user_guide/glossary.qmd#impact-of-changes) can be found in the [glossary](../user_guide/glossary.qmd).
 
 ## Other changes
 

--- a/quality_assurance/assumptions-log.qmd
+++ b/quality_assurance/assumptions-log.qmd
@@ -36,7 +36,7 @@ Our assumptions log has the following columns
 
 This project website is version controlled and therefore historical versions of the assumption log can be found on [GitHub](https://github.com/The-Strategy-Unit/nhp_project_information).
 
-<table id="assumptions-table" class="" style="width:100%">
+<table id="assumptions-table" style="width:100%">
   <thead></thead>
   <tbody></tbody>
 </table>

--- a/quality_assurance/assumptions-log.qmd
+++ b/quality_assurance/assumptions-log.qmd
@@ -9,13 +9,18 @@ format:
       - assumptions.json
     include-in-header:
       text: |
-        <link rel="stylesheet"
-              href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css" />
-        <link rel="stylesheet" href="css/table.css" />
+        <link
+          href="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.3.8/datatables.min.css"
+          rel="stylesheet"
+          integrity="sha384-pq10ZYwmet1tp386fLkrSm/N7RUYsWsdYI3cFFJxvfY91mTNBl96Fw3/u4pYU3l2"
+          crossorigin="anonymous">
+ 
+        <script
+          src="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.3.8/datatables.min.js"
+          integrity="sha384-6GudBuzC533FClgQWy/gDB8pVYcyEr0WN8QDbQu+kNaxeGolpBLCdhBMvrHr7gF8"
+          crossorigin="anonymous"></script>
 
-        <script src="https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js"></script>
-        <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-        <script src="https://cdn.datatables.net/2.3.2/js/dataTables.min.js"></script>
+        <link rel="stylesheet" href="css/table.css" />
         <script src="js/table.js"></script>
 ---
 

--- a/quality_assurance/assumptions-log.qmd
+++ b/quality_assurance/assumptions-log.qmd
@@ -1,6 +1,22 @@
 ---
 title: "Assumptions log"
 order: 2
+format:
+  html:
+    resources:
+      - css/table.css
+      - js/table.js
+      - assumptions.json
+    include-in-header:
+      text: |
+        <link rel="stylesheet"
+              href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css" />
+        <link rel="stylesheet" href="css/table.css" />
+
+        <script src="https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+        <script src="https://cdn.datatables.net/2.3.2/js/dataTables.min.js"></script>
+        <script src="js/table.js"></script>
 ---
 
 The purpose of an assumptions log is to justify any decisions made about the data and methodologies used. 
@@ -15,91 +31,8 @@ Our assumptions log has the following columns
 
 This project website is version controlled and therefore historical versions of the assumption log can be found on [GitHub](https://github.com/The-Strategy-Unit/nhp_project_information).
 
+<table id="assumptions-table" class="" style="width:100%"></table>
 
-```{css}
-.tag {
-  display: inline-block;
-  padding: 0.125rem 0.75rem;
-  border-radius: 15px;
-  font-weight: 600;
-  font-size: 0.75rem;
-}
-
-.status-excellent {
-  background: hsl(116, 60%, 90%);
-  color: hsl(116, 30%, 25%);
-}
-
-.status-good {
-  background: hsl(26, 70%, 90%);
-  color: hsl(26, 45%, 30%);
-}
-
-.status-poor {
-  background: hsl(350, 70%, 90%);
-  color: hsl(350, 45%, 30%);
-}
-
-.status-low {
-  background: hsl(116, 60%, 90%);
-  color: hsl(116, 30%, 25%);
-}
-
-.status-medium {
-  background: hsl(26, 70%, 90%);
-  color: hsl(26, 45%, 30%);
-}
-
-.status-high {
-  background: hsl(350, 70%, 90%);
-  color: hsl(350, 45%, 30%);
-}
-
-```
-
-
-```{r}
-calc_risk <- function(quality, impact) {
-  dplyr::case_when(
-  quality %in% c("good", "excellent") & impact == "low" ~ "low",
-  quality == "poor" & impact == "low" ~ "medium",
-  quality %in% c("good", "excellent") & impact == "medium" ~ "medium",
-  quality == "excellent" & impact == "high" ~ "medium",
-  quality %in% c("poor", "good") & impact == "high" ~ "high",
-  quality == "poor" & impact == "medium" ~ "high"
-)
-}
-
-assumptions <-
-  jsonlite::fromJSON("assumptions.json") |>
-  tibble::as_tibble() |>
-  dplyr::mutate(risk = calc_risk(quality, impact))
-
-assumptions |>
-  dplyr::select(-link) |>
-  reactable::reactable(
-    columns = list( 
-      id = reactable::colDef(name = "ID", maxWidth = 50),
-      description = reactable::colDef(name = "Description", minWidth = 200, html = TRUE,
-      cell = function(value, index) {
-        sprintf('<a href="%s" target="_blank">%s</a>', assumptions$link[index], value)
-      }),
-      quality = reactable::colDef(name = "Quality",
-      cell = function(value) {
-        class <- paste0("tag status-", tolower(value))
-        htmltools::div(class = class, value)
-      }),
-      impact = reactable::colDef(name = "Impact",
-      cell = function(value) {
-        class <- paste0("tag status-", tolower(value))
-        htmltools::div(class = class, value)
-      }),
-      risk = reactable::colDef(name = "Risk",
-      cell = function(value) {
-        class <- paste0("tag status-", tolower(value))
-        htmltools::div(class = class, value)
-      })
-    ),
-    outlined = TRUE
-  )
-```
+<script>
+document.addEventListener("DOMContentLoaded", () => { initTable() });
+</script>

--- a/quality_assurance/assumptions-log.qmd
+++ b/quality_assurance/assumptions-log.qmd
@@ -36,7 +36,10 @@ Our assumptions log has the following columns
 
 This project website is version controlled and therefore historical versions of the assumption log can be found on [GitHub](https://github.com/The-Strategy-Unit/nhp_project_information).
 
-<table id="assumptions-table" class="" style="width:100%"></table>
+<table id="assumptions-table" class="" style="width:100%">
+  <thead></thead>
+  <tbody></tbody>
+</table>
 
 <script>
 document.addEventListener("DOMContentLoaded", () => { initTable() });

--- a/quality_assurance/css/table.css
+++ b/quality_assurance/css/table.css
@@ -1,0 +1,37 @@
+.tag {
+  display: inline-block;
+  padding: 0.125rem 0.75rem;
+  border-radius: 15px;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.status-excellent {
+  background: hsl(116, 60%, 90%);
+  color: hsl(116, 30%, 25%);
+}
+
+.status-good {
+  background: hsl(26, 70%, 90%);
+  color: hsl(26, 45%, 30%);
+}
+
+.status-poor {
+  background: hsl(350, 70%, 90%);
+  color: hsl(350, 45%, 30%);
+}
+
+.status-low {
+  background: hsl(116, 60%, 90%);
+  color: hsl(116, 30%, 25%);
+}
+
+.status-medium {
+  background: hsl(26, 70%, 90%);
+  color: hsl(26, 45%, 30%);
+}
+
+.status-high {
+  background: hsl(350, 70%, 90%);
+  color: hsl(350, 45%, 30%);
+}

--- a/quality_assurance/js/table.js
+++ b/quality_assurance/js/table.js
@@ -10,22 +10,21 @@ function initTable() {
       return response.json();
     })
     .then(rows => {
+      const escapeHtml = value => String(value ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+      const safeHref = href => (/^javascript:/i.test(String(href ?? "").trim()) ? "#" : String(href ?? "").trim());
+
       const data = rows.map(row => {
-        const risk = calcRisk(row.quality, row.impact);
-        return {
-          id: row.id,
-          description: `<a href="${row.link}">${row.description}</a>`,
-          quality: `<div class="tag status-${row.quality}">${row.quality}</div>`,
-          impact: `<div class="tag status-${row.impact}">${row.impact}</div>`,
-          risk: `<div class="tag status-${risk}">${risk}</div>`
-        };
+        const quality = String(row.quality ?? "").toLowerCase();
+        const impact = String(row.impact ?? "").toLowerCase();
+        const risk = calcRisk(quality, impact);
+        return { id: row.id, description: String(row.description ?? ""), link: safeHref(row.link), quality, impact, risk };
       });
       const columns = [
         { data: "id", title: "ID" },
-        { data: "description", title: "Description" },
-        { data: "quality", title: "Quality" },
-        { data: "impact", title: "Impact" },
-        { data: "risk", title: "Risk" }
+        { data: "description", title: "Description", render: (data, type, row) => type === "display" ? `<a href="${escapeHtml(row.link)}" target="_blank" rel="noopener noreferrer">${escapeHtml(data)}</a>` : data },
+        { data: "quality", title: "Quality", render: (data, type) => type === "display" ? `<div class="tag status-${escapeHtml(data)}">${escapeHtml(data)}</div>` : data },
+        { data: "impact", title: "Impact", render: (data, type) => type === "display" ? `<div class="tag status-${escapeHtml(data)}">${escapeHtml(data)}</div>` : data },
+        { data: "risk", title: "Risk", render: (data, type) => type === "display" ? `<div class="tag status-${escapeHtml(data)}">${escapeHtml(data)}</div>` : data }
       ];
 
       new DataTable(selector, {

--- a/quality_assurance/js/table.js
+++ b/quality_assurance/js/table.js
@@ -1,0 +1,59 @@
+function initTable() {
+  const selector = "#assumptions-table";
+
+  return fetch("assumptions.json")
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`Failed to load assumptions JSON (${response.status})`);
+      }
+
+      return response.json();
+    })
+    .then(rows => {
+      const data = rows.map(row => {
+        const risk = calcRisk(row.quality, row.impact);
+        return {
+          id: row.id,
+          description: `<a href="${row.link}">${row.description}</a>`,
+          quality: `<div class="tag status-${row.quality}">${row.quality}</div>`,
+          impact: `<div class="tag status-${row.impact}">${row.impact}</div>`,
+          risk: `<div class="tag status-${risk}">${risk}</div>`
+        };
+      });
+      const columns = [
+        { data: "id", title: "ID" },
+        { data: "description", title: "Description" },
+        { data: "quality", title: "Quality" },
+        { data: "impact", title: "Impact" },
+        { data: "risk", title: "Risk" }
+      ];
+
+      new DataTable(selector, {
+        data: data,
+        columns: columns,
+        pageLength: 25,
+        order: [],
+        scrollX: true,
+        layout: {
+          topStart: "",
+          topEnd: "",
+          bottomStart: "",
+          bottomEnd: ""
+        }
+      });
+    });
+}
+
+
+function calcRisk(quality, impact) {
+  if (quality === "poor") {
+    if (impact === "low") {
+      return "medium";
+    } else {
+      return "high";
+    }
+  } else if (quality === "excellent" && impact === "high") {
+    return "medium";
+  }
+  return impact;
+}

--- a/user_guide/glossary.qmd
+++ b/user_guide/glossary.qmd
@@ -94,10 +94,7 @@ summing the 90th and 10th percentiles from each POD ("Summed").
 ::: {.callout-note collapse="true"} 
 ## Expand to see an example of how to calculate the above using R code
 
-```{r}
-#| echo: true
-#| eval: false
-
+``` r
 library(tidyverse)
 
 #create the synthetic data

--- a/user_guide/js/table.js
+++ b/user_guide/js/table.js
@@ -4,7 +4,10 @@ function initDataTable(selector, data, columns) {
     columns: columns,
     pageLength: 25,
     order: [[0, "asc"]],
-    scrollX: true,
+    autoWidth: false,
+    initComplete: function () {
+      this.api().table().node().style.tableLayout = "fixed";
+    },
     layout: {
       topStart: [
         {
@@ -100,6 +103,17 @@ function transformTpmasRows(lookupRows, mechanismsRaw) {
   });
 }
 
+function applyTableCellWrapping(columns) {
+  return columns.map(column => ({
+    ...column,
+    createdCell: function (td) {
+      td.style.whiteSpace = "normal";
+      td.style.overflowWrap = "anywhere";
+      td.style.wordBreak = "break-word";
+    }
+  }));
+}
+
 async function loadTpmasTable(
   selector,
   {
@@ -121,17 +135,17 @@ async function loadTpmasTable(
 
     const data = transformTpmasRows(lookupRows, mechanismsRaw);
     const columns = [
-      { title: "Code", data: "Code" },
-      { title: "Activity", data: "Activity" },
-      { title: "Type", data: "Type" },
+      { title: "Code", data: "Code", width: "100px" },
+      { title: "Activity", data: "Activity", width: "75px" },
+      { title: "Type", data: "Type", width: "105px" },
       { title: "Name", data: "Name" },
       { title: "Variable", data: "Variable" },
       { title: "Mechanism", data: "Mechanism" },
-      { title: "From", data: "From" },
-      { title: "To", data: "To" }
+      { title: "From", data: "From", width: "70px" },
+      { title: "To", data: "To", width: "70px" }
     ];
 
-    initDataTable(selector, data, columns);
+    initDataTable(selector, data, applyTableCellWrapping(columns));
   } catch (err) {
     console.error("Failed to load TPMA table", err);
   }

--- a/user_guide/js/table.js
+++ b/user_guide/js/table.js
@@ -1,0 +1,128 @@
+function initDataTable(selector, data, columns) {
+  new DataTable(selector, {
+    data: data,
+    columns: columns,
+    pageLength: 25,
+    order: [],
+    scrollX: true,
+    layout: {
+      topStart: "search",
+      topEnd: "pageLength",
+      bottomStart: "info",
+      bottomEnd: "paging"
+    }
+  });
+}
+
+function parseCsvFromUrl(csvUrl) {
+  return new Promise((resolve, reject) => {
+    Papa.parse(csvUrl, {
+      download: true,
+      header: true,
+      dynamicTyping: false,
+      skipEmptyLines: true,
+      complete: function (results) {
+        if (results.errors.length) {
+          reject(results.errors);
+          return;
+        }
+
+        resolve(results.data);
+      },
+      error: function (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function flattenMechanisms(value, out = {}) {
+  if (value === null || value === undefined) {
+    return out;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      flattenMechanisms(item, out);
+    }
+    return out;
+  }
+
+  if (typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      if (nested !== null && typeof nested === "object") {
+        flattenMechanisms(nested, out);
+      } else {
+        out[key] = nested;
+      }
+    }
+  }
+
+  return out;
+}
+
+function toTitleWithSingleUnderscoreReplacement(text) {
+  const title = String(text || "")
+    .toLowerCase()
+    .replace(/\b\w/g, char => char.toUpperCase());
+
+  return title.replace("_", " ");
+}
+
+function transformTpmasRows(lookupRows, mechanismsRaw) {
+  const mechanisms = flattenMechanisms(mechanismsRaw);
+
+  return lookupRows.map(row => {
+    const activity = String(row.activity_type || "");
+    const type = String(row.mitigator_type || "");
+    const toValue = row.active_to;
+
+    return {
+      Code: row.mitigator_code,
+      Activity: activity === "aae" ? "A&E" : activity.toUpperCase(),
+      Type: toTitleWithSingleUnderscoreReplacement(type),
+      Name: row.mitigator_name,
+      Variable: row.mitigator_variable,
+      Mechanism: mechanisms[row.mitigator_code],
+      From: row.active_from,
+      To: toValue === null || toValue === undefined || toValue === "" ? "-" : toValue
+    };
+  });
+}
+
+async function loadTpmasTable(
+  selector,
+  {
+    lookupCsvUrl = "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/main/reference/mitigator-lookup.csv",
+    mechanismsJsonUrl = "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/main/reference/mechanism-lookup.json"
+  } = {}
+) {
+  try {
+    const [lookupRows, mechanismsRaw] = await Promise.all([
+      parseCsvFromUrl(lookupCsvUrl),
+      fetch(mechanismsJsonUrl).then(response => {
+        if (!response.ok) {
+          throw new Error(`Failed to load mechanisms JSON (${response.status})`);
+        }
+
+        return response.json();
+      })
+    ]);
+
+    const data = transformTpmasRows(lookupRows, mechanismsRaw);
+    const columns = [
+      { title: "Code", data: "Code" },
+      { title: "Activity", data: "Activity" },
+      { title: "Type", data: "Type" },
+      { title: "Name", data: "Name" },
+      { title: "Variable", data: "Variable" },
+      { title: "Mechanism", data: "Mechanism" },
+      { title: "From", data: "From" },
+      { title: "To", data: "To" }
+    ];
+
+    initDataTable(selector, data, columns);
+  } catch (err) {
+    console.error("Failed to load TPMA table", err);
+  }
+}

--- a/user_guide/js/table.js
+++ b/user_guide/js/table.js
@@ -3,11 +3,21 @@ function initDataTable(selector, data, columns) {
     data: data,
     columns: columns,
     pageLength: 25,
-    order: [],
+    order: [[0, "asc"]],
     scrollX: true,
     layout: {
-      topStart: "search",
-      topEnd: "pageLength",
+      topStart: [
+        {
+          buttons: [
+            {
+              extend: 'csvHtml5',
+              text: 'Download CSV'
+            }
+          ]
+        },
+
+      ],
+      topEnd: "search",
       bottomStart: "info",
       bottomEnd: "paging"
     }

--- a/user_guide/mitigators_lookup.qmd
+++ b/user_guide/mitigators_lookup.qmd
@@ -41,8 +41,10 @@ There are four mechanisms that a TPMA may relate to:
 3.  De-adoption of low value activities, such as tonsillectomies, grommets, and unnecessary follow-up outpatient attendances. 
 4.  Efficiency gains such as reduced length of stay or virtual wards.
 
-
-<table id="tpma-table" class="display" style="width:100%"></table>
+<table id="tpma-table" class="display" style="width:100%">
+  <thead></thead>
+  <tbody></tbody>
+</table>
 
 <script>
 document.addEventListener("DOMContentLoaded", () => {

--- a/user_guide/mitigators_lookup.qmd
+++ b/user_guide/mitigators_lookup.qmd
@@ -41,7 +41,7 @@ There are four mechanisms that a TPMA may relate to:
 3.  De-adoption of low value activities, such as tonsillectomies, grommets, and unnecessary follow-up outpatient attendances. 
 4.  Efficiency gains such as reduced length of stay or virtual wards.
 
-<table id="tpma-table" class="display" style="width:100%">
+<table id="tpma-table" style="width:100%">
   <thead></thead>
   <tbody></tbody>
 </table>

--- a/user_guide/mitigators_lookup.qmd
+++ b/user_guide/mitigators_lookup.qmd
@@ -1,6 +1,19 @@
 ---
 title: "TPMAs lookup"
 order: 5
+format:
+  html:
+    resources:
+      - js/table.js
+    include-in-header:
+      text: |
+        <link rel="stylesheet"
+              href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css">
+
+        <script src="https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js"></script>
+        <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+        <script src="https://cdn.datatables.net/2.3.2/js/dataTables.min.js"></script>
+        <script src="js/table.js"></script>
 ---
 
 This page contains an interactive table with a sortable and searchable lookup of types of potentially mitigatable activity (TPMAs). Click the 'Download CSV' button to download a copy with the current filters applied (if any).
@@ -19,63 +32,10 @@ There are four mechanisms that a TPMA may relate to:
 4.  Efficiency gains such as reduced length of stay or virtual wards.
 
 
-```{r}
-#| label: mitigators-table
+<table id="tpma-table" class="display" style="width:100%"></table>
 
-library(readr)
-
-lookup <- read_csv(
-  "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/main/reference/mitigator-lookup.csv",
-  col_types = "c"
-)
-
-mechanisms_raw <- jsonlite::read_json(
-  "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/main/reference/mechanism-lookup.json")
-
-# 2. Convert JSON list to a dataframe for joining
-mechanisms_df <- tibble::enframe(unlist(mechanisms_raw), name = "mitigator_code", value = "mechanism")
-
-dat <- lookup |>
-  dplyr::left_join(mechanisms_df, by = "mitigator_code") |> 
-  dplyr::select(
-    Code = mitigator_code,
-    Activity = "activity_type",
-    Type = "mitigator_type",
-    Name = "mitigator_name",
-    Variable = "mitigator_variable",
-    Mechanism = "mechanism",
-    From = "active_from",
-    To = "active_to"
-  ) |>
-  dplyr::mutate(
-    Activity = dplyr::if_else(
-      Activity == "aae",
-      "A&E",
-      stringr::str_to_upper(Activity)
-    ),
-    Type = Type |> stringr::str_to_title() |> stringr::str_replace("_", " ")
-  ) |>
-  tidyr::replace_na(list(To = "-"))
-
-htmltools::tagList(
-  htmltools::tags$button(
-    "Download CSV",
-    onclick = "Reactable.downloadDataCSV('mitigators-data')"
-  ),
-  reactable::reactable(
-    elementId = "mitigators-data",
-    data = dat,
-    defaultSorted = "Code",
-    searchable = TRUE,
-    filterable = TRUE,
-    columns = list(
-      "Code" = reactable::colDef(maxWidth = 100),
-      "Activity" = reactable::colDef(maxWidth = 75),
-      "Type" = reactable::colDef(maxWidth = 105),
-      "From" = reactable::colDef(maxWidth = 70),
-      "To" = reactable::colDef(maxWidth = 70)
-    )
-  )
-) |>
-  htmltools::browsable()
-```
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  loadTpmasTable("#tpma-table");
+});
+</script>

--- a/user_guide/mitigators_lookup.qmd
+++ b/user_guide/mitigators_lookup.qmd
@@ -7,12 +7,22 @@ format:
       - js/table.js
     include-in-header:
       text: |
-        <link rel="stylesheet"
-              href="https://cdn.datatables.net/2.3.2/css/dataTables.dataTables.min.css">
+        <link
+          href="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.3.8/b-3.2.6/b-html5-3.2.6/datatables.min.css"
+          rel="stylesheet"
+          integrity="sha384-1OScWqbx4XgbHvbfZzPSoQ5TfKTHjWXe0jqxPmrngilLvmJ4Z4F8gkX/b9H/q1z4"
+          crossorigin="anonymous">
+        
+        <script
+          src="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.3.8/b-3.2.6/b-html5-3.2.6/datatables.min.js"
+          integrity="sha384-c8v8R8HgB2YgkBbz+W+EB5M/1RKD5wqDVq1GWXpVLlYmI2EJ+qhj03f0LWH4nd3E"
+          crossorigin="anonymous"></script>
 
-        <script src="https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js"></script>
-        <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-        <script src="https://cdn.datatables.net/2.3.2/js/dataTables.min.js"></script>
+        <script
+          src="https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js"
+          integrity="sha384-Jd2/X5FXVKahwaY2nivvw4LfSTg9idSj8yNXWtT4qef0fHSYr6M7M8bJAfbFYoMc"
+          crossorigin="anonymous"></script>
+          
         <script src="js/table.js"></script>
 ---
 


### PR DESCRIPTION
Replaces R code which built the TPMA lookup table and the assumptions log with javascript that performs the same transformation client side.

Changes a code block from \`\`\`{r} to \`\`\` r to prevent need for R to be installed.

(This does not entirely eliminate use of R code blocks, inequalities should be tackled separately)