### PR TITLE
Update text and table on TPMA-lookup page

### DIFF
--- a/user_guide/js/table.js
+++ b/user_guide/js/table.js
@@ -80,8 +80,7 @@ function applyTableCellWrapping(columns) {
 async function loadTpmasTable(
   selector,
   {
-    // TODO: update path when merged to main in TPMAs repo
-    lookupCsvUrl = "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/10-lookup-update/reference/tpma-lookup.csv"
+    lookupCsvUrl = "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/main/reference/tpma-lookup.csv"
   } = {}
 ) {
   try {

--- a/user_guide/js/table.js
+++ b/user_guide/js/table.js
@@ -49,56 +49,18 @@ function parseCsvFromUrl(csvUrl) {
   });
 }
 
-function flattenMechanisms(value, out = {}) {
-  if (value === null || value === undefined) {
-    return out;
-  }
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      flattenMechanisms(item, out);
-    }
-    return out;
-  }
-
-  if (typeof value === "object") {
-    for (const [key, nested] of Object.entries(value)) {
-      if (nested !== null && typeof nested === "object") {
-        flattenMechanisms(nested, out);
-      } else {
-        out[key] = nested;
-      }
-    }
-  }
-
-  return out;
-}
-
-function toTitleWithSingleUnderscoreReplacement(text) {
-  const title = String(text || "")
-    .toLowerCase()
-    .replace(/\b\w/g, char => char.toUpperCase());
-
-  return title.replace("_", " ");
-}
-
-function transformTpmasRows(lookupRows, mechanismsRaw) {
-  const mechanisms = flattenMechanisms(mechanismsRaw);
-
+function transformTpmasRows(lookupRows) {
   return lookupRows.map(row => {
-    const activity = String(row.activity_type || "");
-    const type = String(row.mitigator_type || "");
+    const subtypeValue = row.tpma_subtype;
     const toValue = row.active_to;
 
     return {
-      Code: row.mitigator_code,
-      Activity: activity === "aae" ? "A&E" : activity.toUpperCase(),
-      Type: toTitleWithSingleUnderscoreReplacement(type),
-      Name: row.mitigator_name,
-      Variable: row.mitigator_variable,
-      Mechanism: mechanisms[row.mitigator_code],
+      Code: row.tpma_code,
+      Name: row.tpma_name,
+      Subtype: subtypeValue === "NA" ? "-" : subtypeValue,
+      Mechanism: row.tpma_mechanism,
       From: row.active_from,
-      To: toValue === null || toValue === undefined || toValue === "" ? "-" : toValue
+      To: toValue === "NA" ? "-" : toValue
     };
   });
 }
@@ -117,36 +79,29 @@ function applyTableCellWrapping(columns) {
 async function loadTpmasTable(
   selector,
   {
-    lookupCsvUrl = "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/main/reference/mitigator-lookup.csv",
-    mechanismsJsonUrl = "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/main/reference/mechanism-lookup.json"
+    // TODO: update path when merged to main in TPMAs repo
+    lookupCsvUrl = "https://raw.githubusercontent.com/The-Strategy-Unit/TPMAs/refs/heads/10-lookup-update/reference/tpma-lookup.csv"
   } = {}
 ) {
   try {
-    const [lookupRows, mechanismsRaw] = await Promise.all([
-      parseCsvFromUrl(lookupCsvUrl),
-      fetch(mechanismsJsonUrl).then(response => {
-        if (!response.ok) {
-          throw new Error(`Failed to load mechanisms JSON (${response.status})`);
-        }
+    const lookupRows = await parseCsvFromUrl(lookupCsvUrl);
 
-        return response.json();
-      })
-    ]);
-
-    const data = transformTpmasRows(lookupRows, mechanismsRaw);
+    const data = transformTpmasRows(lookupRows);
     const columns = [
-      { title: "Code", data: "Code", width: "100px" },
-      { title: "Activity", data: "Activity", width: "75px" },
-      { title: "Type", data: "Type", width: "105px" },
+      { title: "Code", data: "Code", width: "95px" },
       { title: "Name", data: "Name" },
-      { title: "Variable", data: "Variable" },
+      { title: "Subtype", data: "Subtype" },
       { title: "Mechanism", data: "Mechanism" },
-      { title: "From", data: "From", width: "70px" },
-      { title: "To", data: "To", width: "70px" }
+      { title: "From", data: "From", width: "65px" },
+      { title: "To", data: "To", width: "65px" }
     ];
 
     initDataTable(selector, data, applyTableCellWrapping(columns));
   } catch (err) {
     console.error("Failed to load TPMA table", err);
+    document.querySelector(selector).insertAdjacentHTML(
+      "afterend",
+      "<p><em>Sorry, the table failed to load.</em></p>"
+    );
   }
 }

--- a/user_guide/js/table.js
+++ b/user_guide/js/table.js
@@ -2,7 +2,7 @@ function initDataTable(selector, data, columns) {
   new DataTable(selector, {
     data: data,
     columns: columns,
-    pageLength: 25,
+    pageLength: 10,
     order: [[0, "asc"]],
     autoWidth: false,
     initComplete: function () {

--- a/user_guide/js/table.js
+++ b/user_guide/js/table.js
@@ -57,7 +57,8 @@ function transformTpmasRows(lookupRows) {
     return {
       Code: row.tpma_code,
       Name: row.tpma_name,
-      Subtype: subtypeValue === "NA" ? "-" : subtypeValue,
+      SubType: subtypeValue === "NA" ? "-" : subtypeValue,
+      ActivityType: row.activity_type,
       Mechanism: row.tpma_mechanism,
       From: row.active_from,
       To: toValue === "NA" ? "-" : toValue
@@ -90,7 +91,8 @@ async function loadTpmasTable(
     const columns = [
       { title: "Code", data: "Code", width: "95px" },
       { title: "Name", data: "Name" },
-      { title: "Subtype", data: "Subtype" },
+      { title: "Sub-type", data: "SubType" },
+      { title: "Activity type", data: "ActivityType" },
       { title: "Mechanism", data: "Mechanism" },
       { title: "From", data: "From", width: "65px" },
       { title: "To", data: "To", width: "65px" }

--- a/user_guide/mitigators_lookup.qmd
+++ b/user_guide/mitigators_lookup.qmd
@@ -12,7 +12,7 @@ format:
           rel="stylesheet"
           integrity="sha384-1OScWqbx4XgbHvbfZzPSoQ5TfKTHjWXe0jqxPmrngilLvmJ4Z4F8gkX/b9H/q1z4"
           crossorigin="anonymous">
-        
+
         <script
           src="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.3.8/b-3.2.6/b-html5-3.2.6/datatables.min.js"
           integrity="sha384-c8v8R8HgB2YgkBbz+W+EB5M/1RKD5wqDVq1GWXpVLlYmI2EJ+qhj03f0LWH4nd3E"
@@ -22,24 +22,47 @@ format:
           src="https://cdn.jsdelivr.net/npm/papaparse@5.5.3/papaparse.min.js"
           integrity="sha384-Jd2/X5FXVKahwaY2nivvw4LfSTg9idSj8yNXWtT4qef0fHSYr6M7M8bJAfbFYoMc"
           crossorigin="anonymous"></script>
-          
+
         <script src="js/table.js"></script>
 ---
 
-This page contains an interactive table with a sortable and searchable lookup of types of potentially mitigatable activity (TPMAs). Click the 'Download CSV' button to download a copy with the current filters applied (if any).
+This page contains an interactive table with a sortable and searchable lookup of types of potentially mitigatable activity (TPMAs).
 
-The table shows the model versions when each TPMA was active from and active to (if deprecated). There were 84 TPMAs in model version 1.0. For model versions 1.1 onwards, there are 92 TPMAs. Virtual Ward and Day Procedures TPMAs were added in [version 1.1](/project_plan_and_summary/model_updates.html#update-20240424). Same Day Emergency Care (SDEC) TPMAs were added and Ambulatory Emergency Care (AEC) TPMAs removed in [version 3.4](http://localhost:5811/project_plan_and_summary/model_updates.html#update-20250423).
+## The current list
 
-The table contains TPMA codes, which exist to make it easier to refer to and discuss TPMAs. These codes take the form 'IP-AA-001', for example. Each code is composed of an activity type ('IP' is inpatient, for example), a TPMA type ('AA' is activity avoidance) and a three-digit number (assigned on the basis of alphabetical order within activity and TPMA types).
+There are 34 TPMAs from model version 1.1 onwards, totalling 92 unique TPMAs in combination with their sub-types.
 
-The variable names for each strategy are also included. These are used when interacting directly with the data that underlies the model and apps. The TPMA names are presented to users in the inputs- and outputs-app interfaces.
+The table shows the model versions when each TPMA was active from and active to (if deprecated).
+Major changes have included that:
+
+* Virtual Ward and Day Procedures TPMAs were added in [version 1.1](/project_plan_and_summary/model_updates.html#update-20240424)
+* Same Day Emergency Care (SDEC) TPMAs were added and Ambulatory Emergency Care (AEC) TPMAs removed in [version 3.4](http://localhost:5811/project_plan_and_summary/model_updates.html#update-20250423)
+
+## Unique codes
+
+The table contains unique TPMA codes, which make it easier to refer to and discuss TPMAs.
+Each code is composed of:
+
+* an activity type, where 'IP' is inpatients, 'OP' is outpatients and 'AE' is accident and emergency
+* a TPMA type, where 'AA' is activity avoidance and 'EF' is efficiencies
+* a three-digit number, which was assigned on the basis of alphabetical order within activity and TPMA types
+
+So, for example, 'IP-AA-001' refers to the first-listed activity-avoidance TPMA within the inpatients activity type.
+
+## Mechanisms
 
 There are four mechanisms that a TPMA may relate to:
 
-1.  Prevention and public health initiatives. This includes hospital activity related to smoking, alcohol consumption, obesity or falls which may be deemed to be avoidable via prevention and public health interventions. 
-2.  Redirection of activity to out-of-hospital settings or the substitution of hospital activity for some alternative out-of-hospital intervention.  This includes ambulatory care sensitive admissions, mental health admissions that may be avoided with psychiatric liaison, admissions of frail older people and low acuity admissions.
-3.  De-adoption of low value activities, such as tonsillectomies, grommets, and unnecessary follow-up outpatient attendances. 
-4.  Efficiency gains such as reduced length of stay or virtual wards.
+1. Prevention and public health initiatives.
+This includes hospital activity related to smoking, alcohol consumption, obesity or falls which may be deemed to be avoidable via prevention and public health interventions.
+2. Redirection of activity to out-of-hospital settings or the substitution of hospital activity for some alternative out-of-hospital intervention.
+This includes ambulatory care sensitive admissions, mental health admissions that may be avoided with psychiatric liaison, admissions of frail older people and low acuity admissions.
+3. De-adoption of low value activities, such as tonsillectomies, grommets, and unnecessary follow-up outpatient attendances.
+4. Efficiency gains such as reduced length of stay or virtual wards.
+
+## TPMA lookup table
+
+Click the 'Download CSV' button to download a copy with the current filters applied (if any).
 
 <table id="tpma-table" style="width:100%">
   <thead></thead>


### PR DESCRIPTION
>[!NOTE]
>Out of draft, but not to be merged until after https://github.com/The-Strategy-Unit/TPMAs/pull/14 is merged and this branch points to that lookup on main.

Close #373.

Re JavaScript:

* read the updated TPMA lookup from [the centralised TPMAs repository](https://github.com/the-Strategy-Unit/tpmas)
* removed handling of the standalone mechanism file, which will no longer exist in the centralised TPMAs repo
* handled `"NA"`, since this is the only blank used in the TPMA lookup
* added a printed warning if the table fails to load

Re Quarto:

* simplified the table (code, name, sub-type, mechanism and active versions) to make the table readable and remove redundant content (i.e. the code contains the activity-type and type)
* added sections for clarity and to improve linking
* tweaked body text to clarify construction of codes and to reference _34_ TPMAs, in particular